### PR TITLE
Add JSDoc header validation and CI checks

### DIFF
--- a/.github/scripts/hc-check-headers-changed-files.cjs
+++ b/.github/scripts/hc-check-headers-changed-files.cjs
@@ -83,7 +83,7 @@ function runHeaderChecks(files, configPath) {
   try {
     // Ensure we're running from the project root (two levels up from this script)
     process.chdir(path.join(__dirname, '..', '..'));
-    const escapedFiles = files.map(f => `"${f.replace(/"/g, '\\"')}"`).join(' ');
+    const escapedFiles = files.map(f => `"${f.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(' ');
     const cfg = configPath ? `--config ${configPath} ` : '';
     const cmd = `node scripts/check-file-headers.mjs ${cfg}${escapedFiles}`;
     console.log(`[hc] Running header check: ${cmd}`);

--- a/.github/scripts/hc-check-headers-changed-files.cjs
+++ b/.github/scripts/hc-check-headers-changed-files.cjs
@@ -7,6 +7,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const _ = require('lodash');
 
 /**
  * Determines changed files between the current HEAD and a specified base ref,
@@ -26,7 +27,7 @@ function determineChangedFiles(baseRef, matchPattern = '\\.(m?js|cjs)$') {
     // Split by null, filter by pattern, and return as array
     const changedFiles = changedRaw
       .split('\0')
-      .filter(file => file && new RegExp(matchPattern).test(file));
+      .filter(file => file && new RegExp(_.escapeRegExp(matchPattern)).test(file));
 
     return changedFiles;
   } catch (error) {

--- a/.github/scripts/hc-check-headers-changed-files.cjs
+++ b/.github/scripts/hc-check-headers-changed-files.cjs
@@ -1,0 +1,133 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Determines changed files between the current HEAD and a specified base ref,
+ * filtered by an optional regex pattern.
+ * @param {string} baseRef - The base ref to compare against (e.g., 'main').
+ * @param {string} [matchPattern='\\.(m?js|cjs)$'] - Regex pattern to filter files.
+ * @returns {string[]} Array of changed file paths matching the pattern.
+ */
+function determineChangedFiles(baseRef, matchPattern = '\\.(m?js|cjs)$') {
+  try {
+    // Fetch the base ref
+    execSync(`git fetch origin ${baseRef} --depth=1`, { stdio: 'inherit' });
+
+    // Get changed files as null-delimited string
+    const changedRaw = execSync(`git diff --name-only -z origin/${baseRef}...HEAD`, { encoding: 'utf8' });
+
+    // Split by null, filter by pattern, and return as array
+    const changedFiles = changedRaw
+      .split('\0')
+      .filter(file => file && new RegExp(matchPattern).test(file));
+
+    return changedFiles;
+  } catch (error) {
+    console.error('Error determining changed files:', error.message);
+    return [];
+  }
+}
+
+/**
+ * Writes a formatted Markdown summary to the GitHub step summary file if available.
+ * @param {string[]} changedFiles - Array of changed file paths.
+ */
+function writeSummary(changedFiles) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return; // Not in CI, skip
+
+  const summary = `# Changed Files Summary\n\n` +
+    `Found ${changedFiles.length} changed file(s) matching the pattern.\n\n` +
+    (changedFiles.length > 0
+      ? changedFiles.map(file => `- \`${file}\``).join('\n')
+      : 'No changes detected.');
+
+  try {
+    fs.appendFileSync(summaryPath, summary + '\n\n');
+  } catch (error) {
+    console.error('Error writing to summary:', error.message);
+  }
+}
+
+/**
+ * Sets the GitHub output by appending the changed files to the GITHUB_OUTPUT file.
+ * @param {Array|string|Object} changedFiles - The list or object of changed files to be serialized and output.
+ */
+function setGitHubOutput(changedFiles) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (outputPath) {
+    try {
+      fs.appendFileSync(outputPath, `changed-files=${JSON.stringify(changedFiles)}\n`);
+    } catch (error) {
+      console.error('Error writing to output:', error.message);
+    }
+  }
+}
+
+/**
+ * Run the header check script for the provided list of files.
+ * @param {string[]} files - Array of file paths to check.
+ * @param {string} configPath - Optional path to header-check config JSON.
+ * @returns {boolean} True if checks passed, false if any failed.
+ */
+function runHeaderChecks(files, configPath) {
+  if (!files || files.length === 0) return true;
+  try {
+    // Ensure we're running from the project root (two levels up from this script)
+    process.chdir(path.join(__dirname, '..', '..'));
+    const escapedFiles = files.map(f => `"${f.replace(/"/g, '\\"')}"`).join(' ');
+    const cfg = configPath ? `--config ${configPath} ` : '';
+    const cmd = `node scripts/check-file-headers.mjs ${cfg}${escapedFiles}`;
+    console.log(`[hc] Running header check: ${cmd}`);
+    execSync(cmd, { stdio: 'inherit' });
+    return true;
+  } catch (error) {
+    console.error('[hc][error] Header check failed:', error.message);
+    return false;
+  }
+}
+
+/**
+ * Main entry point for the script that determines changed files based on a base reference.
+ *
+ * This function expects command-line arguments: a base reference (e.g., a Git commit or branch)
+ * and an optional match pattern for file extensions. It calls `determineChangedFiles` to get
+ * the list of changed files, then outputs the result as JSON to the console.
+ * If running in GitHub Actions, it also writes a formatted summary.
+ *
+ * Usage: node scripts/determine-changed-files.cjs <base-ref> [match-pattern]
+ *
+ * @param {string} baseRef - The base Git reference (e.g., commit SHA or branch name) to compare against.
+ * @param {string} [matchPattern='\\.(m?js|cjs)$'] - Optional regex pattern to match file extensions (defaults to JS/JSX/CJS files).
+ * @throws {Error} If fewer than 2 command-line arguments are provided, exits with code 1 and logs usage error.
+ */
+function main() {
+  if (process.argv.length < 3) {
+    console.error('Usage: node scripts/determine-changed-files.cjs <base-ref> [match-pattern]');
+    process.exit(1);
+  }
+  const baseRef = process.argv[2];
+  const matchPattern = process.argv[3] || '\\.(m?js|cjs)$';
+  // Optional fourth arg: path to header-check config JSON
+  const headerConfig = process.argv[4] || process.env.HEADER_CHECK_CONFIG || 'header-check.config.json';
+  const changedFiles = determineChangedFiles(baseRef, matchPattern);
+
+  // Set output for GitHub Actions
+  setGitHubOutput(changedFiles);
+
+  // Write formatted summary if in CI
+  writeSummary(changedFiles);
+
+  // If there are changed files, run the header check directly here.
+  if (changedFiles.length > 0) {
+    const ok = runHeaderChecks(changedFiles, headerConfig);
+    if (!ok) process.exit(1);
+  } else {
+    console.log('[hc] No changed files matching pattern; skipping header checks.');
+  }
+}
+
+if (require.main === module) {
+  main();
+}

--- a/.github/scripts/hc-check-headers-changed-files.cjs
+++ b/.github/scripts/hc-check-headers-changed-files.cjs
@@ -7,7 +7,6 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
-const _ = require('lodash');
 
 /**
  * Determines changed files between the current HEAD and a specified base ref,

--- a/.github/scripts/hc-check-headers-changed-files.cjs
+++ b/.github/scripts/hc-check-headers-changed-files.cjs
@@ -1,3 +1,9 @@
+/**
+ * @file hc-check-headers-changed-files.cjs
+ * @description Determine changed JS files vs a base ref and run header checks + emit GitHub Actions outputs.
+ * @path .github/scripts/hc-check-headers-changed-files.cjs
+ */
+
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');

--- a/.github/scripts/hc-check-headers-changed-files.cjs
+++ b/.github/scripts/hc-check-headers-changed-files.cjs
@@ -27,7 +27,7 @@ function determineChangedFiles(baseRef, matchPattern = '\\.(m?js|cjs)$') {
     // Split by null, filter by pattern, and return as array
     const changedFiles = changedRaw
       .split('\0')
-      .filter(file => file && new RegExp(_.escapeRegExp(matchPattern)).test(file));
+      .filter(file => file && new RegExp(matchPattern).test(file));
 
     return changedFiles;
   } catch (error) {

--- a/.github/workflows/header-check.yml
+++ b/.github/workflows/header-check.yml
@@ -1,0 +1,28 @@
+name: Header Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  header-check:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+            node-version: '20'
+            cache: 'npm'
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Determine changed files and run header checks
+        id: changed
+        run: node .github/scripts/hc-check-headers-changed-files.cjs ${{ github.base_ref }}
+      - name: No relevant changes
+        if: steps.changed.outputs['changed-files'] == '[]'
+        run: echo "No JS source file changes requiring header validation."

--- a/.github/workflows/header-check.yml
+++ b/.github/workflows/header-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   header-check:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,33 @@ Before marking Ready for Review ensure:
 - [ ] Ran npm test + (optionally) coverage locally
 ```
 
+### Automated Header Enforcement
+
+All changed `*.js`, `*.mjs`, `*.cjs` files in a pull request are validated by the "Header Check" GitHub Action to ensure they begin with the required JSDoc file header block containing at minimum: `@file`, `@description`, `@path`.
+
+Run locally before pushing:
+
+```bash
+npm run check:headers
+```
+
+To customize (rare), create a JSON config and invoke the script directly:
+
+```bash
+node scripts/check-file-headers.mjs --config header-check.config.json path/to/file.js
+```
+
+Current required fields can be extended by editing the optional config JSON with:
+
+```json
+{
+  "requiredFields": ["@file", "@description", "@path", "@author"],
+  "ignoreGlobs": ["tests/*"]
+}
+```
+
+Files missing headers or tags will cause the CI job to fail.
+
 Rebase onto `master` if needed to avoid noisy merge commits.
 
 ---

--- a/README.md
+++ b/README.md
@@ -199,15 +199,35 @@ This project supports path aliases for cleaner imports and better IDE support:
 - `#/*` - Project root
 - `#scripts/*` - Scripts directory
 - `#helpers/*` - Helper modules
-- `#config/*` - Configuration files
-- `#patches/*` - Patch system
-- `#patches/entrypoint/*` - Patch entry points
-- `#patches/common/*` - Common patch utilities
-- `#tests/unit/*` - Unit tests
-- `#tests/integration/*` - Integration tests
-- `#docs/*` - Documentation
-- `#examples/*` - Example configurations
-- `#schemas/*` - JSON schemas
+
+## Automated Header Enforcement
+
+The repository enforces JSDoc-style file headers on source files via a lightweight script and CI check.
+
+- Local check: `npm run check:headers`
+- Script: `scripts/check-file-headers.mjs`
+- CI: `.github/workflows/header-check.yml` (runs on pull requests)
+
+
+Customize requirements by editing `header-check.config.json` at the repository root.
+
+`#config/*` - Configuration files
+
+`#patches/*` - Patch system
+
+`#patches/entrypoint/*` - Patch entry points
+
+`#patches/common/*` - Common patch utilities
+
+`#tests/unit/*` - Unit tests
+
+`#tests/integration/*` - Integration tests
+
+`#docs/*` - Documentation
+
+`#examples/*` - Example configurations
+
+`#schemas/*` - JSON schemas
 
 **Package Exports:**
 External projects can import modules using the package name:

--- a/header-check.config.json
+++ b/header-check.config.json
@@ -1,0 +1,4 @@
+{
+  "ignoreGlobs": ["tests/*", "coverage/*", "examples/*"],
+  "requiredFields": ["@file", "@description", "@path"]
+}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "test:combined": "node --experimental-vm-modules ./node_modules/.bin/jest tests/unit tests/integration --coverage --maxWorkers=1",
     "test:ci": "npm run lint && npm run test:combined",
     "check-coverage": "node .github/scripts/check-coverage.cjs",
-    "validate:package": "bash ./scripts/validate-package.sh"
+    "validate:package": "bash ./scripts/validate-package.sh",
+    "check:headers": "git diff --name-only origin/main...HEAD | xargs node scripts/check-file-headers.mjs --config header-check.config.json"
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -263,3 +263,45 @@ To create a new CLI tool following the entrypoint+common pattern:
 - Validate package.json: `npx scripts/validate-package-json.js`
 - Run package validation script: `./scripts/validate-package.sh`
 - Generate compose with custom output: `npx fvtt-compose-gen -c container-config.json -o custom-compose.yml`
+
+## Header Checker
+
+This repository enforces a JSDoc-style file header on source files via a lightweight script and a GitHub Action.
+
+- **Script**: `scripts/check-file-headers.mjs`
+- **Purpose**: Validate that changed `*.js`, `*.mjs`, and `*.cjs` source files start with a JSDoc header block containing at minimum `@file`, `@description`, and `@path`.
+- **CI**: `.github/workflows/header-check.yml` runs the checker on pull requests and will fail the PR if required tags are missing.
+
+Usage (local):
+
+```bash
+# validate headers for files changed vs origin/main
+npm run check:headers
+
+# validate specific files
+node scripts/check-file-headers.mjs --config header-check.config.json path/to/file.js
+```
+
+Configuration
+
+Place `header-check.config.json` at the repository root to customize behavior. Supported keys:
+
+- `requiredFields` (array): additional JSDoc tags to require (default: `["@file","@description","@path"]`).
+- `ignoreGlobs` (array): glob-like patterns (supports `*`) to skip files from validation.
+
+Example `header-check.config.json`:
+
+```json
+{
+  "ignoreGlobs": ["tests/*", "coverage/*", "examples/*"],
+  "requiredFields": ["@file", "@description", "@path"]
+}
+```
+
+Notes
+
+- The script tolerates an optional shebang (`#!`) and leading blank lines before the header block.
+- The `@file` tag is validated against the actual filename when present; mismatches are reported as errors.
+- The CI action only runs for non-draft pull requests and only examines JS source file changes.
+
+If you'd like the CI to require additional tags or relax rules for particular directories, edit `header-check.config.json`.

--- a/scripts/check-file-headers.mjs
+++ b/scripts/check-file-headers.mjs
@@ -1,0 +1,204 @@
+/**
+ * @file check-file-headers.mjs
+ * @description CLI utility that verifies JavaScript source files include the
+ * required JSDoc header block (e.g. `@file`, `@description`, `@path`).
+ *
+ * The script supports an optional JSON config to override required fields and
+ * ignore globs, tolerates a leading shebang, and performs a best-effort
+ * validation of `@file` and `@path` tag values. It exits with a non-zero
+ * status when any file fails validation which makes it suitable for CI checks
+ * and pre-commit hooks.
+ *
+ * @path scripts/check-file-headers.mjs
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REQUIRED_FIELDS = [
+  '@file',
+  '@description',
+  '@path'
+];
+
+/**
+ * Print usage information to the console.
+ */
+function usage() {
+  console.log(`Usage: node scripts/check-file-headers.mjs [--config optional-json] <file ...>
+
+Examples:
+  node scripts/check-file-headers.mjs src/foo.js
+  git diff --name-only origin/main...HEAD | grep -E '\\.(m?js|cjs)$' | xargs node scripts/check-file-headers.mjs
+
+Options:
+  --config <file>   Optional JSON file to override requiredFields and ignoreGlobs.
+`);
+}
+
+/**
+ * Load configuration from a JSON file.
+ * @param {string} customConfigPath - Path to the JSON config file.
+ * @returns {object} Parsed config object or empty object if no path provided.
+ */
+function loadConfig(customConfigPath) {
+  if (!customConfigPath) return {};
+  try {
+    const raw = fs.readFileSync(customConfigPath, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    console.error(`[headers][error] Failed to load config '${customConfigPath}': ${err.message}`);
+    process.exit(2);
+  }
+}
+
+/**
+ * Check if the file path corresponds to a JavaScript source file.
+ * @param {string} filePath - The file path to check.
+ * @returns {boolean} True if the file is a JS source file (.js, .mjs, .cjs).
+ */
+function isSourceFile(filePath) {
+  return /(\.m?js|\.cjs)$/i.test(filePath);
+}
+
+/**
+ * Read the first bytes of a file as a string.
+ * @param {string} filePath - Path to the file to read.
+ * @param {number} maxBytes - Maximum number of bytes to read (default 4096).
+ * @returns {string} The content of the first bytes as a UTF-8 string.
+ */
+function readFirstBytes(filePath, maxBytes = 4096) {
+  const fd = fs.openSync(filePath, 'r');
+  const buffer = Buffer.alloc(maxBytes);
+  const bytesRead = fs.readSync(fd, buffer, 0, maxBytes, 0);
+  fs.closeSync(fd);
+  return buffer.slice(0, bytesRead).toString('utf8');
+}
+
+/**
+ * Extract the JSDoc header block from file content.
+ * @param {string} content - The file content as a string.
+ * @returns {string[]|null} Array of header lines or null if no header found.
+ */
+function extractHeaderBlock(content) {
+  const lines = content.split(/\n/);
+  let i = 0;
+  // Skip shebang if present
+  if (lines[i] && lines[i].startsWith('#!')) i++;
+  // Skip leading blank lines
+  while (i < lines.length && lines[i].trim() === '') i++;
+  if (!lines[i] || !lines[i].trim().startsWith('/**')) return null;
+  const headerLines = [];
+  for (; i < lines.length; i++) {
+    headerLines.push(lines[i].trim());
+    if (lines[i].includes('*/')) break;
+  }
+  if (!headerLines[headerLines.length - 1].includes('*/')) return null;
+  return headerLines;
+}
+
+/**
+ * Validate the JSDoc header lines against required fields.
+ * @param {string} filePath - Path to the file being validated.
+ * @param {string[]} headerLines - Array of header lines.
+ * @param {string[]} requiredFields - Array of required JSDoc tags.
+ * @returns {string[]} Array of error messages.
+ */
+function validateHeader(filePath, headerLines, requiredFields) {
+  const errors = [];
+  if (!headerLines) {
+    errors.push('Missing JSDoc header block starting at first line.');
+    return errors;
+  }
+  for (const field of requiredFields) {
+    if (!headerLines.some(l => l.includes(field))) {
+      errors.push(`Missing required tag '${field}'.`);
+    }
+  }
+  // Validate @file value matches basename
+  const fileTagLine = headerLines.find(l => l.startsWith('* @file'));
+  if (fileTagLine) {
+    const value = fileTagLine.replace('* @file', '').trim();
+    const base = path.basename(filePath);
+    if (value && value !== base) {
+      errors.push(`@file tag mismatch: expected '${base}' got '${value}'.`);
+    }
+  } else {
+    errors.push('No @file tag line found.');
+  }
+  // Validate @path contains relative path within repo (best effort)
+  const pathTagLine = headerLines.find(l => l.startsWith('* @path'));
+  if (pathTagLine) {
+    const value = pathTagLine.replace('* @path', '').trim();
+    if (!value) {
+      errors.push('@path tag empty.');
+    }
+  } else {
+    errors.push('No @path tag line found.');
+  }
+  return errors;
+}
+
+/**
+ * Main entry point for the header validation script.
+ * @param {string[]} argv - Command line arguments.
+ */
+function main(argv) {
+  const args = argv.slice(2);
+  if (!args.length || args.includes('-h') || args.includes('--help')) {
+    usage();
+    process.exit(0);
+  }
+
+  let configPath;
+  const files = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--config') {
+      configPath = args[++i];
+    } else {
+      files.push(a);
+    }
+  }
+
+  const config = loadConfig(configPath);
+  const requiredFields = config.requiredFields || REQUIRED_FIELDS;
+  const ignoreGlobs = config.ignoreGlobs || [];
+
+  const micromatch = (patterns, value) => {
+    // Minimal matcher: only supports '*' wildcard for this script to avoid new dep.
+    return patterns.some(p => {
+      const regex = new RegExp('^' + p.split('*').map(s => s.replace(/[-/\\^$+?.()|[\]{}]/g, r => '\\' + r)).join('.*') + '$');
+      return regex.test(value);
+    });
+  };
+
+  let hadErrors = false;
+  for (const f of files) {
+    if (!isSourceFile(f)) continue;
+    if (ignoreGlobs.length && micromatch(ignoreGlobs, f)) continue;
+    if (!fs.existsSync(f)) {
+      console.warn(`[headers][warn] Skipping missing file ${f}`);
+      continue;
+    }
+    const content = readFirstBytes(f);
+    const header = extractHeaderBlock(content);
+    const errors = validateHeader(f, header, requiredFields);
+    if (errors.length) {
+      hadErrors = true;
+      console.error(`\n[headers][fail] ${f}`);
+      errors.forEach(e => console.error(`  - ${e}`));
+    } else {
+      console.log(`[headers][ok] ${f}`);
+    }
+  }
+
+  if (hadErrors) {
+    console.error('\n[headers] Validation failed.');
+    process.exit(1);
+  } else {
+    console.log('\n[headers] All files passed.');
+  }
+}
+
+main(process.argv);

--- a/tests/unit/scripts/check-file-headers.unit.test.js
+++ b/tests/unit/scripts/check-file-headers.unit.test.js
@@ -1,3 +1,9 @@
+/**
+ * @file check-file-headers.unit.test.js
+ * @description Unit tests for the check-file-headers.mjs script.
+ * @path tests/unit/scripts/check-file-headers.unit.test.js
+ */
+
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';

--- a/tests/unit/scripts/check-file-headers.unit.test.js
+++ b/tests/unit/scripts/check-file-headers.unit.test.js
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+
+const runner = process.execPath; // node
+const script = path.resolve('scripts/check-file-headers.mjs');
+
+describe('check-file-headers script', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hdrtest-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('passes for valid header', () => {
+    const filePath = path.join(tmpDir, 'good.mjs');
+    const content = `#!/usr/bin/env node\n/**\n * @file good.mjs\n * @description valid header\n * @path ${path.relative(process.cwd(), filePath)}\n */\nexport default 1;\n`;
+    fs.writeFileSync(filePath, content, 'utf8');
+
+    const res = spawnSync(runner, [script, filePath], { encoding: 'utf8' });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/\[headers\]\sAll files passed/);
+  });
+
+  test('fails when header missing', () => {
+    const filePath = path.join(tmpDir, 'bad.mjs');
+    fs.writeFileSync(filePath, 'console.log(1);\n', 'utf8');
+    const res = spawnSync(runner, [script, filePath], { encoding: 'utf8' });
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/Missing JSDoc header block/);
+  });
+
+  test('respects ignoreGlobs in config', () => {
+    const filePath = path.join(tmpDir, 'ignored.mjs');
+    fs.writeFileSync(filePath, 'console.log(1);\n', 'utf8');
+    const cfg = { ignoreGlobs: [path.join(tmpDir, '*')] };
+    const cfgPath = path.join(tmpDir, 'cfg.json');
+    fs.writeFileSync(cfgPath, JSON.stringify(cfg), 'utf8');
+    const res = spawnSync(runner, [script, '--config', cfgPath, filePath], { encoding: 'utf8' });
+    // Because file is ignored, script should exit 0 and report All files passed
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/All files passed/);
+  });
+
+  test('reports @file mismatch', () => {
+    const filePath = path.join(tmpDir, 'realname.mjs');
+    const content = `/**\n * @file wrongname.mjs\n * @description mismatch\n * @path ${path.relative(process.cwd(), filePath)}\n */\n`;
+    fs.writeFileSync(filePath, content, 'utf8');
+    const res = spawnSync(runner, [script, filePath], { encoding: 'utf8' });
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/@file tag mismatch/);
+  });
+});


### PR DESCRIPTION
# Add JSDoc header validation and CI checks

## Summary

This PR introduces automated validation for JSDoc-style headers in source files and adds CI enforcement to ensure consistency across the codebase.

- Add validation for JSDoc-style headers in changed `*.js`, `*.mjs`, and `*.cjs` files.
- Introduce local check command: `npm run check:headers`.
- Provide configuration options in `header-check.config.json` for required fields and ignored files.
- Update documentation in `CONTRIBUTING.md`, `README.md`, and `scripts/README.md` to reflect new header enforcement process.

## Related issue

- None

## Implementation notes

This change adds header validation tooling to maintain code quality and consistency.

Files added:

- `.github/scripts/hc-check-headers-changed-files.cjs`: Helper script to find changed files for CI
- `.github/workflows/header-check.yml`: GitHub Actions workflow enforcing header checks
- `header-check.config.json`: Configuration for header enforcement (required fields, ignores)
- `scripts/check-file-headers.mjs`: Local CLI to validate headers in changed files
- `tests/unit/scripts/check-file-headers.unit.test.js`: Unit tests for the header-check script

Files modified:

- `CONTRIBUTING.md`: Documented header requirement and how to run local checks
- `README.md`: Added note about automated header checks in CI
- `package.json`: Added `check:headers` npm script
- `scripts/README.md`: Documented the `check-file-headers` script and usage

## Key Changes

### Header Validation Implementation

- Added CI workflow to check headers on PRs targeting main/dev branches
- Created local script for developers to validate headers before committing
- Made header requirements configurable via JSON config file
- Limited checks to changed files only for performance

### Documentation Updates

- Updated contributing guide with header requirements
- Added usage instructions for the new check command
- Documented configuration options

## Testing

Run the header checks locally:

```zsh
npm run check:headers
```

This validates headers in all changed files since the base branch.

## How to verify locally

```zsh
npm install
npm run test:ci
npm run check:coverage
npm run check:headers
```

## Docs

- Updated `CONTRIBUTING.md` with header requirements
- Updated `README.md` with CI information
- Updated `scripts/README.md` with script documentation

## PR Checklist

- [x] **File headers**: All new/changed source files include the required JSDoc header block
- [x] **JSDoc**: All exported symbols have JSDoc (`@export` where applicable)
- [x] **Lint & Tests**: Lint passes and tests added/updated (`npm test`)
- [x] **Coverage**: Coverage maintained or improved (see `.github/constants/thresholds.json`)
- [x] **Directory README**: New or changed directories include `README.md` if they expose logic or configs
- [x] **Docs**: `README.md`, `docs/`, and `examples/` updated if user-facing behavior changed
- [x] **No debug logs**: No unnecessary console/debugging output
- [x] **Dependencies**: New dependencies justified in PR description (if any)

## Notes for reviewers

- The CI workflow runs on PRs to ensure headers are validated before merge
- Configuration is flexible via `header-check.config.json`
- Local checks can be run with `npm run check:headers`
